### PR TITLE
Add watch mode to generator

### DIFF
--- a/book-generator/README.md
+++ b/book-generator/README.md
@@ -157,10 +157,13 @@ title: SOMMAIRE
 ```bash
 npm run build          # Générer le livre (avec sauvegarde automatique)
 npm run build-safe     # Générer le livre (sans sauvegarde automatique)
-npm run dev            # Mode développement (futur)
+npm run dev            # Lancer en mode watch
 npm run clean          # Nettoyer le dossier output
 npm run help           # Aide
 ```
+
+Le mode `dev` surveille `config/` et `config/content/` et régénère
+automatiquement le livre à chaque modification.
 
 ### 💾 Système de sauvegarde
 ```bash


### PR DESCRIPTION
## Summary
- introduce chokidar and watch mode in generator.js
- debounce regeneration to avoid loops
- document `npm run dev` watch usage

## Testing
- `node generator.js --help` *(fails: Cannot find module 'fs-extra')*

------
https://chatgpt.com/codex/tasks/task_e_684afa587efc83298b7af78af2c7f49f