### PR TITLE
Add simple book editor server

### DIFF
--- a/book-generator/README.md
+++ b/book-generator/README.md
@@ -310,3 +310,12 @@ npm run build-safe
 # Voir les logs détaillés
 npm run help
 ```
+## ✏️ Interface d'édition rapide
+
+```bash
+npm install        # first time
+npm run editor     # open http://localhost:3000/editor
+```
+
+Les modifications sauvegardées via l'interface mettent à jour `config/content/pages.md` et les fichiers du dossier `config/content/media/`.
+

--- a/book-generator/editor-server.js
+++ b/book-generator/editor-server.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const fs = require('fs-extra');
+const path = require('path');
+const multer = require('multer');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+const contentDir = path.join(__dirname, 'config', 'content');
+const pagesPath = path.join(contentDir, 'pages.md');
+const mediaDir = path.join(contentDir, 'media');
+
+app.use('/media', express.static(mediaDir));
+app.use(express.urlencoded({ extended: true }));
+
+const storage = multer.diskStorage({
+  destination: mediaDir,
+  filename: (req, file, cb) => cb(null, file.originalname)
+});
+const upload = multer({ storage });
+
+app.get('/editor', async (req, res) => {
+  if (req.query.raw) {
+    const data = await fs.readFile(pagesPath, 'utf8');
+    return res.type('text/plain').send(data);
+  }
+  const htmlPath = path.join(__dirname, 'editor.html');
+  res.sendFile(htmlPath);
+});
+
+app.post('/editor', upload.array('media'), async (req, res) => {
+  try {
+    const pageCount = parseInt(req.body.pageCount, 10) || 0;
+    const sections = [];
+    for (let i = 0; i < pageCount; i++) {
+      sections.push(req.body[`page${i}`] || '');
+    }
+    await fs.outputFile(pagesPath, sections.join('\n---\n'));
+    res.redirect('/editor');
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Error saving content');
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Editor server running at http://localhost:${PORT}/editor`);
+});

--- a/book-generator/editor.html
+++ b/book-generator/editor.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Book Editor</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    textarea { width: 100%; height: 200px; }
+    .page { margin-bottom: 20px; }
+  </style>
+</head>
+<body>
+  <h1>Book Editor</h1>
+  <form id="editorForm" method="POST" enctype="multipart/form-data">
+    <div id="pages"></div>
+    <input type="hidden" id="pageCount" name="pageCount" value="0">
+    <p>
+      <label>Upload media: <input type="file" name="media" multiple></label>
+    </p>
+    <button type="submit">Save</button>
+  </form>
+  <script>
+    fetch('/editor?raw=1')
+      .then(r => r.text())
+      .then(text => {
+        const sections = text.split('\n---\n');
+        document.getElementById('pageCount').value = sections.length;
+        const container = document.getElementById('pages');
+        sections.forEach((content, i) => {
+          const div = document.createElement('div');
+          div.className = 'page';
+          div.innerHTML = `<h3>Page ${i + 1}</h3>` +
+            `<textarea name="page${i}">${content}</textarea>`;
+          container.appendChild(div);
+        });
+      });
+  </script>
+</body>
+</html>

--- a/book-generator/package.json
+++ b/book-generator/package.json
@@ -12,14 +12,17 @@
     "backup": "node backup-manager.js create",
     "backup-list": "node backup-manager.js list",
     "backup-restore": "node backup-manager.js restore",
-    "backup-git": "node backup-manager.js git"
+    "backup-git": "node backup-manager.js git",
+    "editor": "node editor-server.js"
   },
   "dependencies": {
     "marked": "^9.1.6",
     "mustache": "^4.2.0",
     "fs-extra": "^11.1.1",
     "chalk": "^4.1.2",
-    "chokidar": "^3.5.3"
+    "chokidar": "^3.5.3",
+    "express": "^4.18.2",
+    "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"


### PR DESCRIPTION
## Summary
- add Express-based editor server to modify pages and upload media
- create a basic HTML editor form
- document how to launch the editor
- include editor start script and dependencies in package.json

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `node editor-server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684bd569d94083299696378fa9a75ac6