### PR TITLE
Improve editor help and build button

### DIFF
--- a/book-generator/editor.html
+++ b/book-generator/editor.html
@@ -11,6 +11,14 @@
 </head>
 <body>
   <h1>Book Editor</h1>
+  <div id="instructions">
+    <p>Start each page with headers like:</p>
+    <pre># Page: my-page
+type: content
+title: My title</pre>
+    <p>Insert media with <code>[IMAGE: file.jpg | description]</code> or <code>[VIDEO: file.mp4 | description]</code>.</p>
+    <p>Separate pages using <code>---</code>.</p>
+  </div>
   <form id="editorForm" method="POST" enctype="multipart/form-data">
     <div id="pages"></div>
     <input type="hidden" id="pageCount" name="pageCount" value="0">
@@ -18,6 +26,7 @@
       <label>Upload media: <input type="file" name="media" multiple></label>
     </p>
     <button type="submit">Save</button>
+    <button type="button" id="buildBtn">Build</button>
   </form>
   <script>
     fetch('/editor?raw=1')
@@ -34,6 +43,16 @@
           container.appendChild(div);
         });
       });
-  </script>
+
+    document.getElementById('buildBtn').addEventListener('click', async () => {
+      try {
+        const res = await fetch('/build', { method: 'POST' });
+        const msg = await res.text();
+        alert(msg);
+      } catch (err) {
+        alert('Build failed');
+      }
+    });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- explain how to structure book pages and embed media
- add Build button next to Save
- alert with server response after sending POST `/build`

## Testing
- `npm run help` *(fails: Cannot find module 'fs-extra')*

------
https://chatgpt.com/codex/tasks/task_e_684c39aab7f483298112f3656967dd56