### PR TITLE
Add navigation instruction in editor

### DIFF
--- a/book-generator/editor.html
+++ b/book-generator/editor.html
@@ -76,6 +76,7 @@ title: My title</pre>
       <span id="pageNumber"></span>
       <button type="button" id="nextBtn">&rarr;</button>
     </div>
+    <p>Use the arrows to flip through pages.</p>
     <input type="hidden" id="pageCount" name="pageCount" value="0">
     <p>
       <label>Upload media: <input type="file" name="media" multiple></label>


### PR DESCRIPTION
## Summary
- add a page-flipping tip below the arrow buttons in `editor.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d90f9f7b08329ad34d19e8198358c