### PR TITLE
Ajout API pages pour l’éditeur

### DIFF
--- a/book-generator/editor-server.js
+++ b/book-generator/editor-server.js
@@ -13,6 +13,7 @@ const mediaDir = path.join(contentDir, 'media');
 
 app.use('/media', express.static(mediaDir));
 app.use(express.urlencoded({ extended: true }));
+app.use(express.text({ type: 'text/plain' }));
 
 const storage = multer.diskStorage({
   destination: mediaDir,
@@ -45,6 +46,42 @@ app.post('/editor', upload.array('media'), async (req, res) => {
     }
     await fs.outputFile(pagesPath, sections.join('\n---\n'));
     res.redirect('/editor');
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Error saving content');
+  }
+});
+
+app.get('/pages/:index', async (req, res) => {
+  try {
+    const idx = parseInt(req.params.index, 10);
+    if (isNaN(idx) || idx < 0) {
+      return res.status(400).send('Invalid index');
+    }
+    const data = await fs.readFile(pagesPath, 'utf8').catch(() => '');
+    const sections = data ? data.split('\n---\n') : [''];
+    const page = sections[idx] || '';
+    res.json({ page, total: sections.length });
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Error reading content');
+  }
+});
+
+app.post('/pages/:index', async (req, res) => {
+  try {
+    const idx = parseInt(req.params.index, 10);
+    if (isNaN(idx) || idx < 0) {
+      return res.status(400).send('Invalid index');
+    }
+    const data = await fs.readFile(pagesPath, 'utf8').catch(() => '');
+    let sections = data ? data.split('\n---\n') : [];
+    while (sections.length <= idx) {
+      sections.push('');
+    }
+    sections[idx] = req.body || '';
+    await fs.outputFile(pagesPath, sections.join('\n---\n'));
+    res.json({ success: true });
   } catch (err) {
     console.error(err);
     res.status(500).send('Error saving content');

--- a/book-generator/editor.html
+++ b/book-generator/editor.html
@@ -85,7 +85,7 @@ title: My title</pre>
     <button type="button" id="buildBtn">Build</button>
   </form>
   <script>
-    let sections = [];
+    let total = 1;
     let current = 0;
 
     const textarea = document.getElementById('pageTextarea');
@@ -94,34 +94,47 @@ title: My title</pre>
     const nextBtn = document.getElementById('nextBtn');
     const pageCountInput = document.getElementById('pageCount');
 
-    function render(idx) {
-      textarea.value = sections[idx] || '';
-      pageNumber.textContent = `Page ${idx + 1} / ${sections.length}`;
-      prevBtn.disabled = idx === 0;
-      nextBtn.disabled = idx === sections.length - 1;
-      current = idx;
+    function updateIndicator() {
+      pageNumber.textContent = `Page ${current + 1} / ${total}`;
+      prevBtn.disabled = current === 0;
+      nextBtn.disabled = current === total - 1;
+      pageCountInput.value = total;
     }
 
-    fetch('/editor?raw=1')
-      .then(r => r.text())
-      .then(text => {
-        sections = text ? text.split('\n---\n') : [''];
-        pageCountInput.value = sections.length;
-        render(0);
+    async function loadPage(idx) {
+      const res = await fetch(`/pages/${idx}`);
+      const data = await res.json();
+      textarea.value = data.page || '';
+      total = data.total;
+      current = idx;
+      updateIndicator();
+    }
+
+    async function savePage(idx, content) {
+      await fetch(`/pages/${idx}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/plain' },
+        body: content
       });
+    }
 
-    prevBtn.addEventListener('click', () => {
-      sections[current] = textarea.value;
-      render(current - 1);
+    loadPage(0);
+
+    prevBtn.addEventListener('click', async () => {
+      await savePage(current, textarea.value);
+      await loadPage(current - 1);
     });
 
-    nextBtn.addEventListener('click', () => {
-      sections[current] = textarea.value;
-      render(current + 1);
+    nextBtn.addEventListener('click', async () => {
+      await savePage(current, textarea.value);
+      await loadPage(current + 1);
     });
 
-    document.getElementById('editorForm').addEventListener('submit', () => {
-      sections[current] = textarea.value;
+    document.getElementById('editorForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      await savePage(current, textarea.value);
+      const text = await fetch('/editor?raw=1').then(r => r.text());
+      const sections = text ? text.split('\n---\n') : [''];
       pageCountInput.value = sections.length;
       const form = document.getElementById('editorForm');
       form.querySelectorAll('.hiddenPage').forEach(e => e.remove());
@@ -133,6 +146,7 @@ title: My title</pre>
         t.className = 'hiddenPage';
         form.appendChild(t);
       });
+      form.submit();
     });
 
     document.getElementById('buildBtn').addEventListener('click', async () => {


### PR DESCRIPTION
## Notes
- Les commandes npm échouent faute de dépendances installées.

## Summary
- expose les routes `GET/POST /pages/:index` dans `editor-server.js`
- envoie/charge les pages une par une depuis `editor.html`
- mise à jour de l’indicateur de page avec le total renvoyé par l’API

## Testing
- `npm run build` *(fails: Cannot find module 'fs-extra')*

------
https://chatgpt.com/codex/tasks/task_e_684d9980cd3483298aadf48707799ae7