### PR TITLE
Add default book template and smarter fallback

### DIFF
--- a/book-generator/generator.js
+++ b/book-generator/generator.js
@@ -13,6 +13,10 @@ class BookGenerator {
         this.configPath = path.join(__dirname, 'config', 'book-config.json');
         this.contentPath = path.join(__dirname, 'config', 'content', 'pages.md');
         this.templatePath = path.join(__dirname, 'templates', 'book-template.html');
+        this.fallbackTemplatePath = path.join(__dirname, 'gabarit', 'index.html');
+        if (!fs.pathExistsSync(this.templatePath)) {
+            this.templatePath = this.fallbackTemplatePath;
+        }
         this.outputPath = path.join(__dirname, 'output');
         this.mediaPath = path.join(__dirname, 'config', 'content', 'media');
         this.backupManager = new BackupManager();
@@ -268,14 +272,23 @@ class BookGenerator {
     }
 
     async loadTemplate() {
-        try {
-            const template = await fs.readFile(this.templatePath, 'utf8');
+        const primary = this.templatePath;
+        const fallback = this.fallbackTemplatePath;
+
+        if (await fs.pathExists(primary)) {
+            const template = await fs.readFile(primary, 'utf8');
             console.log(chalk.green('✓ Template chargé'));
             return template;
-        } catch (error) {
-            console.error(chalk.red('✗ Template non trouvé, création d\'un template par défaut'));
-            return this.createDefaultTemplate();
         }
+
+        if (primary !== fallback && await fs.pathExists(fallback)) {
+            const template = await fs.readFile(fallback, 'utf8');
+            console.log(chalk.green('✓ Template chargé'));
+            return template;
+        }
+
+        console.error(chalk.red('✗ Template non trouvé, création d\'un template par défaut'));
+        return this.createDefaultTemplate();
     }
 
     createDefaultTemplate() {

--- a/book-generator/templates/book-template.html
+++ b/book-generator/templates/book-template.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{book.title}}</title>
+    <style>{{{styles}}}</style>
+</head>
+<body>
+    {{{body}}}
+    <script>{{{scripts}}}</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add minimal `book-template.html` template
- load this template if available or use `gabarit/index.html` as fallback
- keep existing default template as a last resort

## Testing
- `npm run build --silent` *(fails: Cannot find module 'fs-extra')*

------
https://chatgpt.com/codex/tasks/task_e_684dc50413808329935c05f1cf6928fa