### PR TITLE
Ensure editor loads first page every time

### DIFF
--- a/book-generator/editor.html
+++ b/book-generator/editor.html
@@ -127,11 +127,8 @@ title: My title</pre>
       });
     }
 
-    if (!window.initialPage) {
-      loadPage(0);
-    } else {
-      updateIndicator();
-    }
+    updateIndicator();
+    loadPage(0);
 
     prevBtn.addEventListener('click', async () => {
       await savePage(current, textarea.value);


### PR DESCRIPTION
## Summary
- always call `loadPage(0)` when the editor loads
- keep existing initial injection to show content immediately

## Testing
- `npm run build` *(fails: Cannot find module 'fs-extra')*

------
https://chatgpt.com/codex/tasks/task_e_684dd7885fcc8329ad5aaa5b09c1feb8