### PR TITLE
Fix parsePage metadata parsing with blank lines

### DIFF
--- a/book-generator/editor.html
+++ b/book-generator/editor.html
@@ -115,6 +115,9 @@ title: My title</pre>
 
     function parsePage(text) {
       const lines = text.split('\n');
+      while (lines.length && lines[0].trim() === '') {
+        lines.shift();
+      }
       let id = '', type = '', title = '';
       if (lines[0] && lines[0].startsWith('# Page:')) {
         id = lines.shift().replace('# Page:', '').trim();


### PR DESCRIPTION
## Summary
- handle empty lines at the start of a page when parsing in the editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e0010701c8329b78e17904948baf7