### PR TITLE
Implement page insertion in editor

### DIFF
--- a/book-generator/editor-server.js
+++ b/book-generator/editor-server.js
@@ -108,8 +108,8 @@ app.post('/pages/:index', async (req, res) => {
     }
     const data = await fs.readFile(pagesPath, 'utf8').catch(() => '');
     let sections = data ? data.split('\n---\n') : [];
-    while (sections.length <= idx) {
-      sections.push('');
+    if (idx >= sections.length) {
+      return res.status(400).send('Index out of range');
     }
     sections[idx] = req.body || '';
     await fs.outputFile(pagesPath, sections.join('\n---\n'));
@@ -117,6 +117,26 @@ app.post('/pages/:index', async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).send('Error saving content');
+  }
+});
+
+app.post('/pages/:index/insert', async (req, res) => {
+  try {
+    const idx = parseInt(req.params.index, 10);
+    if (isNaN(idx) || idx < 0) {
+      return res.status(400).send('Invalid index');
+    }
+    const data = await fs.readFile(pagesPath, 'utf8').catch(() => '');
+    let sections = data ? data.split('\n---\n') : [];
+    if (idx >= sections.length - 1) {
+      return res.status(400).send('Cannot insert after last page');
+    }
+    sections.splice(idx + 1, 0, '');
+    await fs.outputFile(pagesPath, sections.join('\n---\n'));
+    res.json({ success: true, total: sections.length });
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Error inserting page');
   }
 });
 

--- a/book-generator/editor.html
+++ b/book-generator/editor.html
@@ -88,6 +88,7 @@ title: My title</pre>
       <button type="button" id="prevBtn">&larr;</button>
       <span id="pageNumber"></span>
       <button type="button" id="nextBtn">&rarr;</button>
+      <button type="button" id="addBtn">+</button>
     </div>
     <p>Use the arrows to flip through pages.</p>
     <input type="hidden" id="pageCount" name="pageCount" value="0">
@@ -111,10 +112,14 @@ title: My title</pre>
     const pageNumber = document.getElementById('pageNumber');
     const prevBtn = document.getElementById('prevBtn');
     const nextBtn = document.getElementById('nextBtn');
+    const addBtn = document.getElementById('addBtn');
     const pageCountInput = document.getElementById('pageCount');
 
     function parsePage(text) {
       const lines = text.split('\n');
+      while (lines.length && lines[0].trim() === '') {
+        lines.shift();
+      }
       let id = '', type = '', title = '';
       if (lines[0] && lines[0].startsWith('# Page:')) {
         id = lines.shift().replace('# Page:', '').trim();
@@ -151,11 +156,13 @@ title: My title</pre>
       pageNumber.textContent = `Page ${current + 1} / ${total}`;
       prevBtn.disabled = current === 0;
       nextBtn.disabled = current === total - 1;
+      addBtn.disabled = current === total - 1;
       pageCountInput.value = total;
     }
 
     async function loadPage(idx) {
       const res = await fetch(`/pages/${idx}`);
+      if (!res.ok) return;
       const data = await res.json();
       const parsed = parsePage(data.page || '');
       textarea.value = parsed.body || '';
@@ -186,6 +193,15 @@ title: My title</pre>
 
     nextBtn.addEventListener('click', async () => {
       await savePage(current);
+      await loadPage(current + 1);
+    });
+
+    addBtn.addEventListener('click', async () => {
+      if (current >= total - 1) return;
+      await savePage(current);
+      const res = await fetch(`/pages/${current}/insert`, { method: 'POST' });
+      const data = await res.json();
+      total = data.total;
       await loadPage(current + 1);
     });
 


### PR DESCRIPTION
## Summary
- modify page save route to avoid creating pages when switching
- add a new `/pages/:index/insert` endpoint
- enable adding pages after the current one in the editor UI

## Testing
- `npm test` *(fails: No tests yet)*

------
https://chatgpt.com/codex/tasks/task_e_684e0010701c8329b78e17904948baf7